### PR TITLE
Code of Conduct and Enforcement Policy pages

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,13 +1,13 @@
-# Contributor Covenant Code of Conduct
+# WeAllJS Code of Conduct
 
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+size, disability, ethnicity, gender identity and expression, level of
+experience, technical preferences, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
 
 ## Our Standards
 
@@ -18,57 +18,80 @@ include:
 * Being respectful of differing viewpoints and experiences
 * Gracefully accepting constructive criticism
 * Focusing on what is best for the community
-* Showing empathy towards other community members
+* Showing empathy and kindness towards other community members
 
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+  advances, including when simulated online. The only exception to sexual topics
+  is channels/spaces specifically for topics of sexual identity.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment, deliberate intimidation, or threats.
 * Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+  address, without explicit permission. This includes any sort of "outing" of
+  of any aspect of someone's identity without their consent.
+* Publishing of non-harassing private communication.
+* Any of the above even when [presented as "ironic" or "joking"](https://en.wikipedia.org/wiki/Hipster_racism).
+* Any attempt to present "reverse-ism" versions of the above as violations. Examples of reverse-isms are "reverse racism", "reverse sexism", "heterophobia", and "cisphobia".
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+  professional or community setting.
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
+Community admins are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Admins have the right and responsibility to remove any messages, channels,
+images, or other contributions that are not aligned to this Code of Conduct, or
+to ban temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful. Members expelled from
+events or venues with any sort of paid attendance will not be refunded.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies both within community spaces and in public spaces
+involving the community. This includes the WeAllJS Slack, its Twitter community,
+private email communications in the context of the community, and any events
+where members of the community are participating, as well as adjacent
+communities and venues affecting the community's members.
+
+Depending on the violation, the admins may decide that violations of this code
+of conduct that have happened outside of the scope of the community may deem an
+individual unwelcome in the community, and take appropriate action to maintain
+the comfort and safety of its members.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+**The Admin team will prioritize the well-being and comfort of the recipients of
+the violation over the comfort of the violator.**
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+The detailed enforcement procedure for any violation of the WeAllJS community
+standards can be found at the [Enforcement Procedures](/enforcement.html) page.
+
+[tl;dr](https://en.wikipedia.org/wiki/TL%3BDR): Use one of the following methods
+to contact the admin staff when you believe a violation has occurred:
+
+* Use the `/admin` command in the WeAllJS Slack to send a message directly to the admin channel.
+* Direct Message [@WeAllJS](https://twitter.com/wealljs) on Twitter with the details and any relevant links.
+* Email the admins directly at [coc@wealljs.org](mailto:coc@wealljs.org)
+* Directly message any admin in private (through either Twitter, Slack, or email, as available) if it is a preferred or more comfortable avenue.
+
+Please include any relevant details, links, screenshots, context, or
+other information that may be used to better understand and resolve the
+situation.
+
+The admin team will do its best to address the issue in a timely manner and
+follow the [enforcement procedure](/enforcement.html). They will, within
+reason, keep you up to date on progress and respect reasonable boundaries.
+
+Admins and other leaders who do not follow or enforce the Code of Conduct in
+good faith may face temporary or permanent repercussions as determined by other
+members of the community's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version], and the LGBTQ in
+Technology Slack [Code of Conduct](http://lgbtq.technology/coc.html).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,23 +2,23 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of
-experience, technical preferences, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as members of
+the WeAllJS community pledge to making participation in our community a
+harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+technical preferences, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy and kindness towards other community members
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive feedback.
+* Focusing on what is best for the community.
+* Showing empathy and kindness towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
@@ -33,6 +33,7 @@ Examples of unacceptable behavior by participants include:
 * Publishing of non-harassing private communication.
 * Any of the above even when [presented as "ironic" or "joking"](https://en.wikipedia.org/wiki/Hipster_racism).
 * Any attempt to present "reverse-ism" versions of the above as violations. Examples of reverse-isms are "reverse racism", "reverse sexism", "heterophobia", and "cisphobia".
+* Unsolicited explanations under the assumption that someone doesn't already know it. Ask before you teach! Don't assume what people's knowledge gaps are.
 * Other conduct which could reasonably be considered inappropriate in a
   professional or community setting.
 
@@ -43,14 +44,15 @@ behavior and are expected to take appropriate and fair corrective action in
 response to any instances of unacceptable behavior.
 
 Admins have the right and responsibility to remove any messages, channels,
-images, or other contributions that are not aligned to this Code of Conduct, or
-to ban temporarily or permanently any contributor for other behaviors that they
-deem inappropriate, threatening, offensive, or harmful. Members expelled from
-events or venues with any sort of paid attendance will not be refunded.
+images, or other contributions that are not aligned with this Code of Conduct,
+or to ban temporarily or permanently any member or participant for other
+behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Members expelled from events or venues with any sort of paid attendance will not
+be refunded.
 
 ## Scope
 
-This Code of Conduct applies both within community spaces and in public spaces
+This Code of Conduct applies both within community spaces and in other spaces
 involving the community. This includes the WeAllJS Slack, its Twitter community,
 private email communications in the context of the community, and any events
 where members of the community are participating, as well as adjacent
@@ -58,8 +60,8 @@ communities and venues affecting the community's members.
 
 Depending on the violation, the admins may decide that violations of this code
 of conduct that have happened outside of the scope of the community may deem an
-individual unwelcome in the community, and take appropriate action to maintain
-the comfort and safety of its members.
+individual unwelcome, and take appropriate action to maintain the comfort and
+safety of its members.
 
 ## Enforcement
 
@@ -69,8 +71,9 @@ the violation over the comfort of the violator.**
 The detailed enforcement procedure for any violation of the WeAllJS community
 standards can be found at the [Enforcement Procedures](/enforcement.html) page.
 
-[tl;dr](https://en.wikipedia.org/wiki/TL%3BDR): Use one of the following methods
-to contact the admin staff when you believe a violation has occurred:
+[tl;dr](https://en.wikipedia.org/wiki/TL%3BDR): Mention the issue to the person
+involved, if possible, and if needed, use one of the following methods to
+contact the admin staff when you believe a violation has occurred:
 
 * Use the `/admin` command in the WeAllJS Slack to send a message directly to the admin channel.
 * Direct Message [@WeAllJS](https://twitter.com/wealljs) on Twitter with the details and any relevant links.
@@ -82,8 +85,8 @@ other information that may be used to better understand and resolve the
 situation.
 
 The admin team will do its best to address the issue in a timely manner and
-follow the [enforcement procedure](/enforcement.html). They will, within
-reason, keep you up to date on progress and respect reasonable boundaries.
+follow the [enforcement procedure](/enforcement.html). They will, within reason,
+keep you up to date on progress and do their best respect reasonable boundaries.
 
 Admins and other leaders who do not follow or enforce the Code of Conduct in
 good faith may face temporary or permanent repercussions as determined by other

--- a/enforcement.md
+++ b/enforcement.md
@@ -1,0 +1,41 @@
+# tl;dr
+
+1. Tell someone "hey, that's not ok".
+2. That person should apologize immediately and correct the behavior.
+3. If this doesn't happen, isn't safe to do, or is not satisfactory, message admins.
+4. Admins will take appropriate in a timely manner, prioritizing those who were hurt.
+
+# Introduction
+
+No matter how kind or nice people think they are, at some point, someone's gonna
+say Some Shit:tm: and things are going to go awry. This document is meant as
+a writeup and guideline holding core values about what this community considers
+the best approach to resolving these conflicts in a kind and positive way, as
+much as possible. It is a living document, informed by new problems, new
+conflicts, and always strives to help make the We All JS community successful
+while including the voices of those who are too often not heard.
+
+# Guiding Principles
+
+This guide is opinionated, and it considers the following to be core values that guide the specific conflict resolution procedure, and future changes to it.
+
+1. **Be Kind**: this is not necessarily the same as being nice. There is a justice involved in being kind. It involves genuine consideration for the situation, and understanding one's own, and others', roles both in this community and in larger society. It involves empathy and education.
+2. **Amygdala make conflict resolution hard**: When a conflict starts, people often enter fight-or-flight mode, which reduces their ability to look at what's in front of them with a kind lens, and reduces the context they're able to reach for in order to understand what's actually going on.
+3. **Inaction is Oppression**: Taking too long to take action when someone is hurt by default benefits the person who did harm. While it's important to be kind, and to understand the situation, things must be handled in a timely manner, and at least some measures must be taken right away to prevent those who were harmed from being the ones who are actually punished.
+4. **We All Fuck Up**: Mistakes happen. Not everyone has had a wide enough range of cultural and personal experience to understand what is seen as unkind or outright hurtful by folks they may not have had access to. This means that it's important to prioritize education, and conflict resolution processes that focus on improving and moving forward, instead of making examples of people.
+5. **[Intersectionality](https://en.wikipedia.org/wiki/Intersectionality) is Important**: The way we related to each other, specially in greatly diverse communities, is often complex and complicated. This means that often, conflicts between people who belong to different intersections require care and consideration in handling, and being informed about those complex relationships.
+6. **The Safety of the hurt takes priority over the Comfort of the ones causing harm**.
+7. **Trust the Ouch**: It's more likely that if someone says they're hurt, they really are hurt, and you should listen and trust them on it, even (and especially if) you don't understand why or how.
+8. **Education is Emotional Labor**: and the one who was hurt does not owe you an explanation or a 101. It's ok to expect people to do their own thinking and research when told there was a wrong, and correct the behavior, instead of placing undue burden on someone who's already been hurt or who is already frustrated with the situation.
+9. **Support is something we can promise -- not Safety**: We don't believe safety, as a general thing is something we can reasonable promise members of a community. Harm comes suddenly, often unexpectedly. Instead, we believe it's a more worthwhile endeavor to try and prevent harm from happening through education, documentation, and policy, and build trust with the community that **when** something happens, they won't have to fight tooth and nail for even basic fairness.
+
+# When an Admin Gets involved
+
+1. Admin will identify themself as an admin of this community, and assert their role in maintaining the well-being of this space.
+2. The Admin will remind the user of the CoC and point out their behavior
+3. Admin should stick to/reference what was said in the conversation
+4. Admin should suggest an alternative behavior (rephrasing using specific language, moving the conversation to another channel if it's offtopic)
+5. If behavior persists, the violators will be removed from the specific channel (`/remove`).
+6. Admin will give them a warning via DM and have them read the CoC again.
+7. If a problem still persists with user after a warning, their account should be disabled for 12-24 hours, with an explanation to return after that time.
+8. If the problem still continues with a user, or the violation is so flagrant, endangering, or otherwise harmful, the user's account will be permanently disabled. Determining whether a violation is serious enough to warrant permanent banning is ultimately up to the admin, who should consult with those who felt harmed by the particular actions.


### PR DESCRIPTION
This is a customized version of the [Contributor Covenant v1.4](http://contributor-covenant.org/version/1/4/code_of_conduct.md), with elements from both the [LGBTQ in Technology Slack CoC](http://lgbtq.technology/coc.html) and the [Community Code of Conduct](https://communitycodeofconduct.com/).

Additionally, it includes an enforcement policy as a separate page, which is partly based on personal experience, and partly based on the admin procedure document for lgbtq.technology written by jk
