### PR TITLE
Add missing colour to landing page

### DIFF
--- a/_posts/2000-01-01-landing.md
+++ b/_posts/2000-01-01-landing.md
@@ -1,5 +1,6 @@
 ---
 title: "home"
+bg: orange
 bgimg: img/wocintechchat/three-coders.jpg
 color: black
 style: center


### PR DESCRIPTION
I noticed the landing page didn’t have the highlight colour as the other pages, so I just added it on the post page.

| Before | After |
| :-: | :-: |
| ![image](https://cloud.githubusercontent.com/assets/385232/17838948/b33b2c28-67d1-11e6-93ad-8bafb260f276.png) | ![image](https://cloud.githubusercontent.com/assets/385232/17838951/bb40fc90-67d1-11e6-88ba-338e9d810e15.png) |
