### PR TITLE
adding point about misuse of content warnings

### DIFF
--- a/_pages/code-of-conduct.md
+++ b/_pages/code-of-conduct.md
@@ -38,7 +38,7 @@ Examples of unacceptable behavior by participants include:
   * The use of sexualized language or imagery and unwelcome sexual attention or advances, including when simulated online. The only exception to sexual topics is channels/spaces specifically for topics of sexual identity.
   * Trolling, insulting/derogatory comments, and personal or political attacks.
   * Casual mention of slavery or indentured servitude and/or false comparisons of one's occupation or situation to slavery. Please consider using or asking about alternate terminology when referring to such metaphors in technology.
-  * Making light of/making mocking comments about trigger warnings and content warnings. Using calls for content warnings/trigger warnings as a way to mock technology, programming languages, or another person's presumed skill level.
+  * Making light of/making mocking comments about trigger warnings and content warnings.
   * Public or private harassment, deliberate intimidation, or threats.
   * Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of "outing" of any aspect of someone's identity without their consent.
   * Publishing screenshots or quotes, especially from identity channels, without all quoted users' *explicit* consent.

--- a/_pages/code-of-conduct.md
+++ b/_pages/code-of-conduct.md
@@ -38,6 +38,7 @@ Examples of unacceptable behavior by participants include:
   * The use of sexualized language or imagery and unwelcome sexual attention or advances, including when simulated online. The only exception to sexual topics is channels/spaces specifically for topics of sexual identity.
   * Trolling, insulting/derogatory comments, and personal or political attacks.
   * Casual mention of slavery or indentured servitude and/or false comparisons of one's occupation or situation to slavery. Please consider using or asking about alternate terminology when referring to such metaphors in technology.
+  * Making light of/making mocking comments about trigger warnings and content warnings. Using calls for content warnings/trigger warnings as a way to mock technology, programming languages, or another person's presumed skill level.
   * Public or private harassment, deliberate intimidation, or threats.
   * Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of "outing" of any aspect of someone's identity without their consent.
   * Publishing screenshots or quotes, especially from identity channels, without all quoted users' *explicit* consent.


### PR DESCRIPTION
I think this, like the change in `weallbehave` could use a little clarity. Suggestions on language changes welcome.