### PR TITLE
Replace markdown-emoji :tm: with ™ glyph

### DIFF
--- a/_pages/enforcement.md
+++ b/_pages/enforcement.md
@@ -9,7 +9,7 @@ permalink: /enforcement
 ## Introduction
 
 No matter how kind or nice people think they are, at some point, someone's gonna
-say Some Shit:tm: and things are going to go awry. This document is meant as a
+say Some Shit™ and things are going to go awry. This document is meant as a
 writeup and guideline holding core values about what this community considers
 the best approach to resolving these conflicts in a kind and positive way, as
 much as possible. It is paired with the community's [Code of


### PR DESCRIPTION
The emoji-variant renders as the literal `:tm:` on the website, so unless that was intentional I decided to replace it with the actual glyph here.

Alternatives include:

- _That's the joke_, so leave it as is
- Use the actual ™️ emoji inline instead of `:tm:` so it renders as intended
- Rewrite it

![options](https://cloud.githubusercontent.com/assets/520420/26779089/53f025e8-49e4-11e7-8679-0c053a8789e1.png)